### PR TITLE
New references

### DIFF
--- a/cppquiz/quiz/templatetags/quiz_extras.py
+++ b/cppquiz/quiz/templatetags/quiz_extras.py
@@ -8,7 +8,11 @@ from django.utils.safestring import mark_safe
 register = template.Library()
 
 def standard_ref(text):
-    return re.sub(u'(§[\d\.]+[¶\d]*)', '<em>\\1</em>', text)
+    possible_named_reference = u'(\[\S+(\.\S+)*\])?'
+    numbered_reference = u'§\d+(\.\d+)*'
+    possible_pilcrow_reference = u'(¶\d+(\.\d+)*)*'
+    regex = '(' + possible_named_reference + '\(?' + numbered_reference + '\)?' + possible_pilcrow_reference + ')'
+    return re.sub(regex, '<em>\\1</em>', text)
 
 def custom_linebreaks(text):
     return (text

--- a/cppquiz/quiz/templatetags/quiz_extras_test.py
+++ b/cppquiz/quiz/templatetags/quiz_extras_test.py
@@ -12,10 +12,14 @@ class standard_ref_Test(unittest.TestCase):
         self.assertEqual(u'<em>§3</em>', standard_ref(u'§3'))
 
     def test_given_sub_paragraph_references(self):
-        self.assertEqual(u'<em>§3.4</em>', standard_ref(u'§3.4'))
+        self.assertEqual(u'<em>§3.45</em>', standard_ref(u'§3.45'))
 
     def test_given_pilcrow_references(self):
-        self.assertEqual(u'<em>§3.4¶1</em>', standard_ref(u'§3.4¶1'))
+        self.assertEqual(u'<em>§33.44¶16.123</em>', standard_ref(u'§33.44¶16.123'))
+
+    def test_given_name_references(self):
+        self.assertEqual(u'<em>[foo]§3.4</em>', standard_ref(u'[foo]§3.4'))
+        self.assertEqual(u'<em>[foo.bar.baz]§3.4¶1</em>', standard_ref(u'[foo.bar.baz]§3.4¶1'))
 
     def test_doesnt_include_too_much(self):
         self.assertEqual(u'<em>§3.4¶1</em>.', standard_ref(u'§3.4¶1.'))

--- a/templates/base.html
+++ b/templates/base.html
@@ -56,7 +56,7 @@ $(document).ready(function() {
 <a href="/quiz/about">Help/FAQ</a> |
 <a href="https://github.com/knatten/cppquiz/issues">Report issues</a> |
 <a href="https://twitter.com/CppQuiz" class="twitter-follow-button" data-show-count="false" data-lang="en">Follow @CppQuiz</a> |
-v1.3 |
+v1.4 |
 © <a href="http://knatten.org">Anders Schau Knatten</a> {% now "Y"%}.
 </p>
 <p class="footer">


### PR DESCRIPTION
We're changing from referring to the standard like this: §10.2¶5
To this: [class.member.lookup]§10.2¶5

So fix highlighting to support that.