### PR TITLE
Remove extra linebreaks before paragraphs

### DIFF
--- a/cppquiz/quiz/templatetags/quiz_extras.py
+++ b/cppquiz/quiz/templatetags/quiz_extras.py
@@ -18,6 +18,7 @@ def custom_linebreaks(text):
     return (text
         .replace("\n", "<br />")
         .replace("</p><br />", "</p>")
+        .replace("<br /><p>", "<p>")
         .replace("</pre><br />", "</pre>"))
 
 @register.filter(needs_autoescape=True)


### PR DESCRIPTION
Fixes #129 

Before:
![screen shot 2018-09-15 at 13 40 55](https://user-images.githubusercontent.com/727543/45585889-0ecee480-b8ed-11e8-814e-3639a0287967.png)

After:
![screen shot 2018-09-15 at 13 41 03](https://user-images.githubusercontent.com/727543/45585890-10001180-b8ed-11e8-94c8-d3dce86f55d6.png)

