### PR TITLE
Paragraph links

### DIFF
--- a/cppquiz/quiz/templatetags/quiz_extras.py
+++ b/cppquiz/quiz/templatetags/quiz_extras.py
@@ -7,29 +7,24 @@ from django.utils.safestring import mark_safe
 
 register = template.Library()
 
-def format_paragraph(section_name, paragraph_number, full_text):
+def format_reference(match):
+    full_reference = match.group(0)
+    section_name = match.group('section_name')
+    paragraph_number = match.group('paragraph')
     if section_name:
-        prefix = "https://timsong-cpp.github.io/cppwp/n4659/"
-        full_link = prefix + section_name
+        full_link = "https://timsong-cpp.github.io/cppwp/n4659/" + section_name
         if paragraph_number:
             full_link = full_link + "#" + paragraph_number
-        return "<em><a href=\"" + full_link + "\">" + full_text + "</a></em>"
+        return "<em><a href=\"" + full_link + "\">" + full_reference + "</a></em>"
     else:
-        return "<em>" + full_text + "</em>"
+        return "<em>" + full_reference + "</em>"
 
 def standard_ref(text):
-    possible_named_reference = '(\[(\S+(\.\S+)*)\])?'
-    numbered_reference = '§\d+(\.\d+)*'
-    possible_pilcrow_reference = '(¶(\d+(\.\d+)*))*'
-    regex = re.compile('(' + possible_named_reference + '\(?' + numbered_reference + '\)?' + possible_pilcrow_reference + ')')
-    matched = regex.findall(text)
-    for elem in matched:
-        full_paragraph = elem[0]
-        section_name = elem[2]
-        paragraph_number = elem[6]
-        text = text.replace(full_paragraph,
-           format_paragraph(section_name, paragraph_number, full_paragraph))
-    return text
+    possible_section_name = u'(\[(?P<section_name>\w+(\.\w+)*)\])?'
+    section_number = u'§\d+(\.\d+)*'
+    possible_paragraph = u'(¶(?P<paragraph>\d+(\.\d+)*))*'
+    regex = re.compile('(' + possible_section_name + section_number + possible_paragraph + ')')
+    return re.sub(regex, format_reference, text)
 
 def custom_linebreaks(text):
     return (text

--- a/cppquiz/quiz/templatetags/quiz_extras_test.py
+++ b/cppquiz/quiz/templatetags/quiz_extras_test.py
@@ -19,23 +19,23 @@ class standard_ref_Test(unittest.TestCase):
 
     def test_given_name_references(self):
         self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">[foo]\xa73.4</a></em>', standard_ref('[foo]§3.4'))
-        # self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">[foo]\xa73.4</a></em>some_symbols', standard_ref('[foo]§3.4some_symbols'))
+        self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">[foo]\xa73.4</a></em>some_symbols', standard_ref('[foo]§3.4some_symbols'))
         self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>', standard_ref('[foo.bar.baz]§3.4¶1'))
 
     def test_doesnt_include_too_much(self):
         self.assertEqual('<em>§3.4¶1</em>.', standard_ref('§3.4¶1.'))
-        # self.assertEqual('(<em>§3.4</em>)', standard_ref('(§3.4)'))
+        self.assertEqual('(<em>§3.4</em>)', standard_ref('(§3.4)'))
 
     def test_given_multiple_paragraphs(self):
         self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">[foo]\xa73.4</a></em>, '
                          '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>',
                           standard_ref('[foo]§3.4, [foo.bar.baz]§3.4¶1'))
-        # self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>, '
-        #                  '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>',
-        #                   standard_ref('[foo.bar.baz]§3.4¶1, [foo.bar.baz]§3.4¶16'))
-        # self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>, '
-        #                  '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>',
-        #                   standard_ref('[foo.bar.baz]§3.4¶16, [foo.bar.baz]§3.4¶1'))
-        # self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>, '
-        #                  '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>',
-        #                   standard_ref('[foo.bar.baz]§3.4¶16, [foo.bar.baz]§3.4¶16'))
+        self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>, '
+                         '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>',
+                          standard_ref('[foo.bar.baz]§3.4¶1, [foo.bar.baz]§3.4¶16'))
+        self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>, '
+                         '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>',
+                          standard_ref('[foo.bar.baz]§3.4¶16, [foo.bar.baz]§3.4¶1'))
+        self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>, '
+                         '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>',
+                          standard_ref('[foo.bar.baz]§3.4¶16, [foo.bar.baz]§3.4¶16'))

--- a/cppquiz/quiz/templatetags/quiz_extras_test.py
+++ b/cppquiz/quiz/templatetags/quiz_extras_test.py
@@ -19,12 +19,23 @@ class standard_ref_Test(unittest.TestCase):
 
     def test_given_name_references(self):
         self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">[foo]\xa73.4</a></em>', standard_ref('[foo]§3.4'))
+        # self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">[foo]\xa73.4</a></em>some_symbols', standard_ref('[foo]§3.4some_symbols'))
         self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>', standard_ref('[foo.bar.baz]§3.4¶1'))
 
     def test_doesnt_include_too_much(self):
         self.assertEqual('<em>§3.4¶1</em>.', standard_ref('§3.4¶1.'))
+        # self.assertEqual('(<em>§3.4</em>)', standard_ref('(§3.4)'))
 
     def test_given_multiple_paragraphs(self):
         self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">[foo]\xa73.4</a></em>, '
                          '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>',
                           standard_ref('[foo]§3.4, [foo.bar.baz]§3.4¶1'))
+        # self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>, '
+        #                  '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>',
+        #                   standard_ref('[foo.bar.baz]§3.4¶1, [foo.bar.baz]§3.4¶16'))
+        # self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>, '
+        #                  '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#1">[foo.bar.baz]\xa73.4\xb61</a></em>',
+        #                   standard_ref('[foo.bar.baz]§3.4¶16, [foo.bar.baz]§3.4¶1'))
+        # self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>, '
+        #                  '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar.baz#16">[foo.bar.baz]\xa73.4\xb616</a></em>',
+        #                   standard_ref('[foo.bar.baz]§3.4¶16, [foo.bar.baz]§3.4¶16'))


### PR DESCRIPTION
Bugfix for links to the standard

In ae2d127e0ec2, we added automatic links to the standard for all references. This didn't work in all cases though, as reported by @wrazik in #156.

This commit fixes #156. Thanks to @vsklamm who added tests to reproduce the problem.