### PR TITLE
Compiler explorer options

### DIFF
--- a/cppquiz/quiz/templatetags/quiz_extras.py
+++ b/cppquiz/quiz/templatetags/quiz_extras.py
@@ -65,14 +65,29 @@ def compiler_explorer_link(question):
         "type": "component",
         "componentName": "compiler",
         "componentState": {
+            "id": 1,
             "source": 1,
             "compiler": "g92",
+            "filters": {"b": 1, "execute": 1, "intel": 1, "commentOnly": 1, "directives": 1},
             "options": f"-std={settings.CPP_STD.lower()}",
         },
     }
 
-    content = [editor, compiler]
-    obj = {"version": 4, "content": [{"type": "row", "content": content}]}
+    output = {
+        "type": "component",
+        "componentName": "output",
+        "componentState": {"compiler": 1, "source": 1},
+    }
+
+    obj = {
+        "version": 4,
+        "content": [
+            {
+                "type": "row",
+                "content": [editor, {"type": "column", "content": [compiler, output]}],
+            }
+        ],
+    }
 
     payload = json.dumps(obj)
     ceFragment = urllib.parse.quote(payload)

--- a/cppquiz/quiz/templatetags/quiz_extras.py
+++ b/cppquiz/quiz/templatetags/quiz_extras.py
@@ -64,7 +64,11 @@ def compiler_explorer_link(question):
     compiler = {
         "type": "component",
         "componentName": "compiler",
-        "componentState": {"source": 1, "compiler": "g92"},
+        "componentState": {
+            "source": 1,
+            "compiler": "g92",
+            "options": f"-std={settings.CPP_STD.lower()}",
+        },
     }
 
     content = [editor, compiler]


### PR DESCRIPTION
This tells the compiler to use C++17, and enables execution of the program. It also adds an output window.

Try it out here: http://beta.cppquiz.org/quiz/question/217?result=OK&answer=21&did_answer=Answer

Looks like this:
![Screenshot from 2019-10-15 13-31-33](https://user-images.githubusercontent.com/727543/66827986-3bba5480-ef50-11e9-86be-0a9966da6a9d.png)


Fixes #168 