### PR TITLE
Allow https in tweets

### DIFF
--- a/cppquiz/quiz/model_test.py
+++ b/cppquiz/quiz/model_test.py
@@ -51,3 +51,5 @@ class QuestionTest(TestCase):
         with self.assertRaises(ValidationError) as cm:
             q.save()
         self.assertIn('Tweets must contain a url!', str(cm.exception))
+        Question(state="SCH", hint = 'hint', tweet_text="http://", difficulty=1).save()
+        Question(state="SCH", hint = 'hint', tweet_text="https://", difficulty=1).save()

--- a/cppquiz/quiz/models.py
+++ b/cppquiz/quiz/models.py
@@ -1,6 +1,7 @@
  # -*- coding: utf-8 -*-
 import datetime
 import random
+import re
 import string
 
 from django.core.exceptions import ValidationError
@@ -60,7 +61,7 @@ class Question(models.Model):
             raise ValidationError(f'Cannot {verbs[self.state]} a question without a difficulty setting')
         if self.state in ('PUB', 'SCH') and self.reserved:
             raise ValidationError(f'Cannot {verbs[self.state]} a reserved question')
-        if self.tweet_text and not "http://" in self.tweet_text:
+        if self.tweet_text and not re.match("https?://",self.tweet_text):
             raise ValidationError('Tweets must contain a url!')
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
When saving a question with a Tweet text, we check that it contains a
link to the question. Previously the site was served as http, so we
checked for the presence of `http://`. Now we serve the site over https,
so let's support both and check for either `http://` or `https://`.

Fixes #193