### PR TITLE
Bugfix for tweet linter

### DIFF
--- a/cppquiz/quiz/model_test.py
+++ b/cppquiz/quiz/model_test.py
@@ -51,5 +51,5 @@ class QuestionTest(TestCase):
         with self.assertRaises(ValidationError) as cm:
             q.save()
         self.assertIn('Tweets must contain a url!', str(cm.exception))
-        Question(state="SCH", hint = 'hint', tweet_text="http://", difficulty=1).save()
-        Question(state="SCH", hint = 'hint', tweet_text="https://", difficulty=1).save()
+        Question(state="SCH", hint = 'hint', tweet_text="See http://example.com", difficulty=1).save()
+        Question(state="SCH", hint = 'hint', tweet_text="See https://example.com", difficulty=1).save()

--- a/cppquiz/quiz/models.py
+++ b/cppquiz/quiz/models.py
@@ -61,7 +61,7 @@ class Question(models.Model):
             raise ValidationError(f'Cannot {verbs[self.state]} a question without a difficulty setting')
         if self.state in ('PUB', 'SCH') and self.reserved:
             raise ValidationError(f'Cannot {verbs[self.state]} a reserved question')
-        if self.tweet_text and not re.match("https?://",self.tweet_text):
+        if self.tweet_text and not re.search("https?://",self.tweet_text):
             raise ValidationError('Tweets must contain a url!')
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
In d7cd7f6 I started allowing https links in tweets, but the unit tests
weren't good enough, so I committed a bug in the regex:

`re.match` requires to match at the beginning of the text, but we want
the URL to be allowed to be anywhere in the tweet, so we should have
used `re.search`.