### PR TITLE
Disable cache for urls with dynamic behaviour

### DIFF
--- a/cppquiz/quiz/views.py
+++ b/cppquiz/quiz/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import render, get_object_or_404
 from django.core.mail import mail_admins
 from django.contrib.admin.views.decorators import staff_member_required
 from django.db.models import Count, Q
+from django.views.decorators.cache import never_cache
 
 from . import fixed_quiz
 from .models import *
@@ -17,9 +18,12 @@ from .game_data import *
 from .quiz_in_progress import *
 from . import system_info
 
+@never_cache
 def index(request):
     return random_question(request)
 
+
+@never_cache
 def random_question(request):
     try:
         return HttpResponseRedirect(


### PR DESCRIPTION
Both the `/` and `/quiz/random` urls lead you to a new random question
each time, even if the url doesn't change. So if someone client side
were to cache these urls, they might end up at the same question over
and over.

This decorator changes the cache control headers from

```
cache-control: max-age=600
```

to

```
cache-control: max-age=0, no-cache, no-store, must-revalidate
```

(Tested with `curl -D -  https://beta.cppquiz.org/quiz/random`)

The undesired cache behaviour has only been reproduced with the Ghostery
and uBlock Origin ad blockers. Big thanks to @vsklamm for discovering
the issue and nailing down exactly what it took to reproduce this.

Fixes #200