### PR TITLE
Fix bug in formatting standard references

### DIFF
--- a/cppquiz/quiz/templatetags/quiz_extras.py
+++ b/cppquiz/quiz/templatetags/quiz_extras.py
@@ -21,7 +21,7 @@ def format_reference(match):
     return "<em><a href=\"" + full_link + "\">" + full_reference + "</a></em>"
 
 def standard_ref(text):
-    section_name = u'(\[(?P<section_name>\w+(\.\w+)*)\])?'
+    section_name = u'(\[(?P<section_name>\w+(\.\w+)*)\])'
     possible_paragraph = u'(¶(?P<paragraph>\d+(\.\d+)*))*'
     regex = re.compile('§(' + section_name + possible_paragraph + ')')
     return re.sub(regex, format_reference, text)

--- a/cppquiz/quiz/templatetags/quiz_extras_test.py
+++ b/cppquiz/quiz/templatetags/quiz_extras_test.py
@@ -24,6 +24,10 @@ class standard_ref_Test(unittest.TestCase):
     def test_doesnt_include_too_much(self):
         self.assertEqual('<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar#1">§[foo.bar]¶1</a></em>.', standard_ref('§[foo.bar]¶1.'))
 
+    def test_doesnt_try_to_format_numbered_references(self):
+        self.assertEqual('§1.2.3', standard_ref('§1.2.3'))
+        self.assertEqual('§1.2.3¶1', standard_ref('§1.2.3¶1'))
+
     def test_given_multiple_paragraphs(self):
         self.assertEqual(
             '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">§[foo]</a></em>'


### PR DESCRIPTION
The `?` at the end of the `section_name` regex was a remnant from when
we used both names and numbers to refer to sections in the standard. It
should have been removed in 78dac93482.

When I failed to remove it, `standard_ref` would try to format section
references using numbers, such as `§1.2.3` (see the unit test). We no
longer use those kinds of references, but some text, when copied from
the standard, still does. So we need to just leave those alone.

Without this fix, we'd get an exception in `format_reference` since
`section_name` would be `None`:

```
TypeError: can only concatenate str (not "NoneType") to str
```