### PR TITLE
Support colons in standard references

### DIFF
--- a/cppquiz/quiz/templatetags/quiz_extras.py
+++ b/cppquiz/quiz/templatetags/quiz_extras.py
@@ -21,7 +21,7 @@ def format_reference(match):
     return "<em><a href=\"" + full_link + "\">" + full_reference + "</a></em>"
 
 def standard_ref(text):
-    section_name = u'(\[(?P<section_name>\w+(\.\w+)*)\])'
+    section_name = u'(\[(?P<section_name>[\w:]+(\.[\w:]+)*)\])'
     possible_paragraph = u'(¶(?P<paragraph>\d+(\.\d+)*))*'
     regex = re.compile('§(' + section_name + possible_paragraph + ')')
     return re.sub(regex, format_reference, text)

--- a/cppquiz/quiz/templatetags/quiz_extras_test.py
+++ b/cppquiz/quiz/templatetags/quiz_extras_test.py
@@ -15,6 +15,9 @@ class standard_ref_Test(unittest.TestCase):
         self.assertEqual(
             '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar">§[foo.bar]</a></em>',
             standard_ref('§[foo.bar]'))
+        self.assertEqual(
+            '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo::bar">§[foo::bar]</a></em>',
+            standard_ref('§[foo::bar]'))
 
     def test_given_section_and_paragraph(self):
         self.assertEqual(


### PR DESCRIPTION
Some sections in the standard have colons in their names, such as
[ios::openmode]. This commit makes sure those are also turned into links
in question explanations.

Fixes #176