### PR TITLE
Hardcode Ubuntu 20.04 in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]


### PR DESCRIPTION
Python 3.6 is not supported on ubuntu-latest, and we need to keep supporting it. See more info at https://github.com/actions/setup-python/issues/543