### PR TITLE
Ignore answers to retracted questions

### DIFF
--- a/quiz/game_data.py
+++ b/quiz/game_data.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from quiz.models import *
+
 
 class UserData:
     def __init__(self, session):
@@ -13,7 +15,7 @@ class UserData:
             self.attempts = defaultdict(int)
 
     def get_correctly_answered_questions(self):
-        return self.correctly_answered
+        return set(Question.objects.filter(pk__in=self.correctly_answered, state='PUB').values_list('pk', flat=True))
 
     def register_correct_answer(self, question_id):
         self.correctly_answered.add(question_id)

--- a/quiz/test_session.py
+++ b/quiz/test_session.py
@@ -2,6 +2,7 @@ import mock
 import unittest
 
 from quiz.game_data import *
+from quiz.models import *
 
 
 class UserDataTest(unittest.TestCase):
@@ -11,24 +12,45 @@ class UserDataTest(unittest.TestCase):
         s = UserData(session)
         self.assertSetEqual(set(), s.get_correctly_answered_questions())
 
-    def test_given_new_session__after_a_correct_answer_is_registered__it_is_listed_as_answered(self):
+    def test_given_new_session__after_a_correct_answer_to_a_published_question_is_registered__it_is_listed_as_answered(self):
+        q1 = Question.objects.create(state='PUB', difficulty=1)
+        q2 = Question.objects.create(state='PUB', difficulty=1)
         session = {}
         s = UserData(session)
-        s.register_correct_answer(23)
-        self.assertSetEqual({23}, s.get_correctly_answered_questions())
-        s.register_correct_answer(4)
-        self.assertSetEqual({4, 23}, s.get_correctly_answered_questions())
+        s.register_correct_answer(q1.pk)
+        self.assertSetEqual({q1.pk}, s.get_correctly_answered_questions())
+        s.register_correct_answer(q2.pk)
+        self.assertSetEqual({q1.pk, q2.pk}, s.get_correctly_answered_questions())
+
+    def test_given_new_session__after_a_correct_answer_to_a_retracted_question_is_registered__it_is_not_listed_as_answered(self):
+        q = Question.objects.create(state='RET', difficulty=1)
+        session = {}
+        s = UserData(session)
+        s.register_correct_answer(q.pk)
+        self.assertSetEqual(set(), s.get_correctly_answered_questions())
+
+    def test_given_new_session__after_a_published_question_becomes_retracted__its_answer_is_not_listed_as_answered(self):
+        q = Question.objects.create(state='PUB', difficulty=1)
+        session = {}
+        s = UserData(session)
+        s.register_correct_answer(q.pk)
+        self.assertSetEqual({q.pk}, s.get_correctly_answered_questions())
+        q.state = 'RET'
+        q.save()
+        self.assertSetEqual(set(), s.get_correctly_answered_questions())
 
     def test_given_existing_session__correct_answers_are_still_there(self):
+        q = Question.objects.create(state='PUB', difficulty=1)
         old_data = UserData({})
-        old_data.register_correct_answer(16)
+        old_data.register_correct_answer(q.pk)
         session = {'user_data': old_data}
         new_data = UserData(session)
-        self.assertSetEqual({16}, new_data.get_correctly_answered_questions())
+        self.assertSetEqual({q.pk}, new_data.get_correctly_answered_questions())
 
     def test_clear_correct_answers(self):
+        q = Question.objects.create(state='PUB', difficulty=1)
         s = UserData({})
-        s.register_correct_answer(23)
+        s.register_correct_answer(q.pk)
         s.clear_correct_answers()
         self.assertSetEqual(set(), s.get_correctly_answered_questions())
 
@@ -41,9 +63,10 @@ class save_user_dataTest(unittest.TestCase):
         self.assertTrue(session.modified)
 
     def test_sets_user_data(self):
+        q = Question.objects.create(state='PUB', difficulty=1)
         session = mock.MagicMock()
         user_data = UserData({})
-        user_data.register_correct_answer(53)
+        user_data.register_correct_answer(q.pk)
         save_user_data(user_data, session)
         session.__setitem__.assert_called_once_with('user_data', user_data)
 


### PR DESCRIPTION
Tests should add questions to the database now, since the function `get_correctly_answered_questions()` checks the state of the answer's question.

Closes https://github.com/knatten/cppquiz/issues/118.

Regarding 

> We do `Question.objects.filter(state='PUB')` quite a few places, so maybe we should extract a helper method `published_questions()` or something.

I want to address that in a different PR dedicated to refactoring (since there are some other snippets worth of extracting).