### PR TITLE
Allow GitHub Actions to run on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: Continuous Integration
 
 on:
   push:
+  pull_request:
   schedule:
     - cron:  '0 0 * * 1'
 


### PR DESCRIPTION
This should allow us to manually run the GitHub Actions workflow in PRs from forks. It will not run manually, but admins should be able to approve the run in the PR UI. See
https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks