### PR TITLE
Reformat whitespace according to PEP8

### DIFF
--- a/cppquiz/local_settings_example.py
+++ b/cppquiz/local_settings_example.py
@@ -8,7 +8,7 @@ settings.ADMINS = (
 
 settings.DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': 'django.db.backends.sqlite3',  # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': '/path/to/your/code/cppquiz/db.sqlite3',                      # Or path to database file if using sqlite3.
         'USER': '',                      # Not used with sqlite3.
         'PASSWORD': '',                  # Not used with sqlite3.
@@ -20,7 +20,7 @@ settings.DATABASES = {
 settings.TEMPLATES[0]['DIRS'].append('/path/to/your/code/cppquiz/templates')
 settings.TEMPLATES[0]['OPTIONS']['debug'] = True
 
-settings.STATIC_ROOT=''
-settings.STATIC_URL='/static/'
+settings.STATIC_ROOT = ''
+settings.STATIC_URL = '/static/'
 
 settings.EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'

--- a/cppquiz/settings.py
+++ b/cppquiz/settings.py
@@ -84,14 +84,14 @@ STATICFILES_FINDERS = (
 SECRET_KEY = '9@&ll@=k-+)s_&@rk334fksoy$clt#!2_@3w%mgrrv2pbh_+b^'
 
 MIDDLEWARE = [
-     'django.middleware.security.SecurityMiddleware',
-     'django.contrib.sessions.middleware.SessionMiddleware',
-     'django.middleware.common.CommonMiddleware',
-     'django.middleware.csrf.CsrfViewMiddleware',
-     'django.contrib.auth.middleware.AuthenticationMiddleware',
-     'django.contrib.messages.middleware.MessageMiddleware',
-     'django.middleware.clickjacking.XFrameOptionsMiddleware',
- ]
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
 
 ROOT_URLCONF = 'cppquiz.urls'
 
@@ -146,8 +146,8 @@ LOGGING = {
     },
     'formatters': {
         'simple_stamped': {
-            'format' : "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
-            'datefmt' : "%Y-%b-%d %H:%M:%S",
+            'format': "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
+            'datefmt': "%Y-%b-%d %H:%M:%S",
         },
     },
     'handlers': {
@@ -156,7 +156,7 @@ LOGGING = {
             'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler',
         },
-        'file' : {
+        'file': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
             'filename': here('quiz.log'),
@@ -178,8 +178,8 @@ LOGGING = {
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
-TOP_WARNING=''
+TOP_WARNING = ''
 
-CPP_STD='C++17'
+CPP_STD = 'C++17'
 
 from . import local_settings

--- a/quiz/admin.py
+++ b/quiz/admin.py
@@ -9,21 +9,22 @@ def result_short(obj):
     return obj.result
 
 class QuestionAdmin(admin.ModelAdmin):
-    list_display=('pk', 'state', 'author_email', 'reserved', 'reservation_message', question_part, result_short, 'answer', 'difficulty', 'date_time', 'publish_time')
-    list_filter=('state', 'difficulty', 'result')
-    search_fields=('question', 'explanation')
-    readonly_fields=('date_time','last_viewed')
+    list_display = ('pk', 'state', 'author_email', 'reserved', 'reservation_message', question_part, result_short, 'answer', 'difficulty', 'date_time', 'publish_time')
+    list_filter = ('state', 'difficulty', 'result')
+    search_fields = ('question', 'explanation')
+    readonly_fields = ('date_time', 'last_viewed')
 
     def view_on_site(self, obj):
         return reverse('quiz:question', args=[obj.pk]) + "?preview_key=" + obj.preview_key
 
 class UsersAnswerAdmin(admin.ModelAdmin):
-    list_display=('question', 'result', 'answer', 'correct', 'ip', 'date_time')
-    list_filter=('question',)
+    list_display = ('question', 'result', 'answer', 'correct', 'ip', 'date_time')
+    list_filter = ('question',)
 
 class QuizAdmin(admin.ModelAdmin):
-    list_display=('key', 'date_time', 'question_ids')
-    search_fields=('key',)
+    list_display = ('key', 'date_time', 'question_ids')
+    search_fields = ('key',)
+
 
 admin.site.register(Question, QuestionAdmin)
 admin.site.register(UsersAnswer, UsersAnswerAdmin)

--- a/quiz/api.py
+++ b/quiz/api.py
@@ -6,6 +6,6 @@ def quiz(request):
     quiz_key = request.GET.get('key')
     try:
         quiz = [q.id for q in Quiz.objects.get(key=quiz_key).get_ordered_questions()]
-        return JsonResponse({'questions':quiz})
+        return JsonResponse({'questions': quiz})
     except Quiz.DoesNotExist:
         raise Http404

--- a/quiz/features/contribute.py
+++ b/quiz/features/contribute.py
@@ -15,7 +15,7 @@ def i_should_see_the_contribute_form(step):
 @step('I fill in "(.*)" as the question and "(.*)" as the explanation')
 def i_fill_in_the_question_and_explanation(step, question, explanation):
     world.browser.fill('question', question)
-    world.browser.fill('explanation',explanation)
+    world.browser.fill('explanation', explanation)
     world.browser.find_by_name('to_moderation').click()
 
 @step('The administrators should get an email about a new question')

--- a/quiz/forms.py
+++ b/quiz/forms.py
@@ -16,9 +16,9 @@ class QuestionForm(ModelForm):
         model = Question
         fields = ('question', 'result', 'answer', 'explanation', 'hint', 'comment', 'difficulty', 'author_email', 'spam_protection')
         widgets = {
-            'question': forms.Textarea(attrs={'rows':20}),
-            'hint': forms.Textarea(attrs={'rows':5}),
-            'comment': forms.Textarea(attrs={'rows':5})
+            'question': forms.Textarea(attrs={'rows': 20}),
+            'hint': forms.Textarea(attrs={'rows': 5}),
+            'comment': forms.Textarea(attrs={'rows': 5})
         }
 
     def clean_question(self):

--- a/quiz/game_data.py
+++ b/quiz/game_data.py
@@ -32,4 +32,4 @@ class UserData:
 def save_user_data(user_data, session):
     session.modified = True
     session['user_data'] = user_data
-    session.set_expiry(60*60*24*365*10)
+    session.set_expiry(60 * 60 * 24 * 365 * 10)

--- a/quiz/integration_tests/test_api.py
+++ b/quiz/integration_tests/test_api.py
@@ -27,4 +27,4 @@ class ApiTest(TestCase):
 
     def test_asking_for_nonexisting_quiz_raises_404(self):
         request = RequestFactory().get('_/?key=this_key_should_not_exist')
-        self.assertRaises(Http404, lambda:api.quiz(request))
+        self.assertRaises(Http404, lambda: api.quiz(request))

--- a/quiz/integration_tests/test_fixed_quiz.py
+++ b/quiz/integration_tests/test_fixed_quiz.py
@@ -24,7 +24,7 @@ class FixedQuizIntegrationTest(TestCase):
         first_question_in_quiz = Quiz.objects.all()[0].get_ordered_questions()[0].pk
         self.assertContains(response, 'Question #%d' % first_question_in_quiz)
 
-        self.assert_status_string_with(response, 0,0)
+        self.assert_status_string_with(response, 0, 0)
 
     def test_correctly_answering_a_question_which_is_not_the_last__congratulates_you_and_takes_you_to_the_next_question(self):
         create_questions(fixed_quiz.nof_questions_in_quiz)
@@ -35,7 +35,7 @@ class FixedQuizIntegrationTest(TestCase):
         self.assertContains(response, 'Correct!')
         explanation = Question.objects.get(pk=pk).explanation
         self.assertContains(response, explanation)
-        self.assert_status_string_with(response, 1,1)
+        self.assert_status_string_with(response, 1, 1)
         self.assertEqual(1, UsersAnswer.objects.count())
 
     def test_incorrectly_answering_a_question__redisplays_it_with_a_message_and_an_option_to_skip_it(self):
@@ -64,7 +64,7 @@ class FixedQuizIntegrationTest(TestCase):
         self.assertContains(response, '>a hint<')
         self.assertContains(response, 'Hint', count=0)
 
-        response = self.client.get(reverse('quiz:quiz', args=(key,)), {'hint':'1'})
+        response = self.client.get(reverse('quiz:quiz', args=(key,)), {'hint': '1'})
         self.assertContains(response, '>a hint<', count=0)
         self.assertContains(response, 'Hint')
         response = self.answer_correctly(key, quiz.get_ordered_questions()[0].pk)
@@ -123,16 +123,16 @@ class FixedQuizIntegrationTest(TestCase):
         question = Question.objects.get(pk=question_pk)
         return self.client.get(
             reverse('quiz:quiz', args=(key,)),
-            {'result':question.result, 'answer':question.answer, 'did_answer':'Answer'},
+            {'result': question.result, 'answer': question.answer, 'did_answer': 'Answer'},
             follow=True)
 
     def answer_incorrectly(self, key):
         return self.client.get(
             reverse('quiz:quiz', args=(key,)),
-            {'result':'NONSENSE', 'answer':'WROOOONG', 'did_answer':'Answer'},
+            {'result': 'NONSENSE', 'answer': 'WROOOONG', 'did_answer': 'Answer'},
             follow=True)
 
     def skip(self, key):
         return self.client.get(
             reverse('quiz:quiz', args=(key,)),
-            {'skip':1})
+            {'skip': 1})

--- a/quiz/integration_tests/test_training.py
+++ b/quiz/integration_tests/test_training.py
@@ -45,7 +45,7 @@ class TrainingIntegrationTest(TestCase):
     def test_when_viewing_a_correctly_answered_question__is_not_told_about_giving_up(self):
         question = self.create_question(True)
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}),
-            {'did_answer': 'answer', 'result':question.result, 'answer':question.answer})
+                                   {'did_answer': 'answer', 'result': question.result, 'answer': question.answer})
         self.assertContains(response, 'Correct')
         self.assertNotContains(response, 'more attempts first')
 
@@ -82,8 +82,8 @@ class TrainingIntegrationTest(TestCase):
         self.assertLess((timezone.now() - Question.objects.get(pk=question.pk).last_viewed).total_seconds(), 10)
 
     def create_question(self, published, preview_key=''):
-        return Question.objects.create(state = 'PUB' if published else 'NEW', question='fluppa', answer='buppa', result='OK', hint='jotta', difficulty=1, preview_key=preview_key)
+        return Question.objects.create(state='PUB' if published else 'NEW', question='fluppa', answer='buppa', result='OK', hint='jotta', difficulty=1, preview_key=preview_key)
 
     def answer_question_incorrectly(self, question):
         return self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}),
-            {'did_answer': 'answer', 'result':question.result, 'answer':'wrong'})
+                               {'did_answer': 'answer', 'result': question.result, 'answer': 'wrong'})

--- a/quiz/management/commands/auto_publish.py
+++ b/quiz/management/commands/auto_publish.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
             secrets_file = Path.home() / ".cppquiz-secrets.json"
             with secrets_file.open() as f:
                 secrets = json.load(f)
-            auth = tweepy.OAuthHandler(secrets["consumer_key"],secrets["consumer_secret"])
+            auth = tweepy.OAuthHandler(secrets["consumer_key"], secrets["consumer_secret"])
             auth.set_access_token(secrets["key"], secrets["secret"])
             api = tweepy.API(auth)
             api.update_status(content)

--- a/quiz/management/commands/create_issues.py
+++ b/quiz/management/commands/create_issues.py
@@ -8,7 +8,6 @@ from quiz.management.commands import text_generator
 
 class Command(BaseCommand):
 
-
     def add_arguments(self, parser):
         parser.add_argument('user', nargs=1)
         parser.add_argument('repo', nargs=1)
@@ -19,12 +18,12 @@ class Command(BaseCommand):
             print("Creating issue for " + str(q.id))
             title = 'Update question ' + str(q.id)
             body = text_generator.get_issue(q)
-            data = json.dumps({'issue' : {'title' : title, 'body' : body}})
+            data = json.dumps({'issue': {'title': title, 'body': body}})
             url = 'https://api.github.com/repos/' + options['user'][0] + '/' + options['repo'][0] + '/import/issues'
             headers = {
-                'Authorization' : 'token ' + options['token'][0],
-                'Accept' : 'application/vnd.github.golden-comet-preview+json'
+                'Authorization': 'token ' + options['token'][0],
+                'Accept': 'application/vnd.github.golden-comet-preview+json'
             }
             request = urllib.request.Request(url, data, headers)
-            response=urllib.request.urlopen(request)
+            response = urllib.request.urlopen(request)
             print(response.read())

--- a/quiz/management/commands/create_questions.py
+++ b/quiz/management/commands/create_questions.py
@@ -11,13 +11,14 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         print(options['nof_questions'])
         for i in range(0, options['nof_questions'][0]):
-            q = Question.objects.create(question='', answer='', result='OK', state='PUB', hint='no hint', difficulty=randint(1,3), explanation='')
+            q = Question.objects.create(question='', answer='', result='OK', state='PUB', hint='no hint', difficulty=randint(1, 3), explanation='')
             q.question = question.replace("pk", str(q.pk))
             q.answer = str(q.pk)
             q.hint = "It's " + str(q.pk)
             q.comment = "I'm pretty sure it's " + str(q.pk)
             q.explanation = "Because " + str(q.pk) + ", see §[over.best.ics]¶6 in the standard."
             q.save()
+
 
 question = """#include <iostream>
 

--- a/quiz/management/commands/dump_published_questions.py
+++ b/quiz/management/commands/dump_published_questions.py
@@ -13,10 +13,10 @@ class Command(BaseCommand):
             questions.append({
                 "id": q.id,
                 "question": q.question,
-                "result" : q.result,
-                "answer" : q.answer,
-                "explanation" : q.explanation,
-                "hint" : q.hint,
-                "difficulty" : q.difficulty,
+                "result": q.result,
+                "answer": q.answer,
+                "explanation": q.explanation,
+                "hint": q.hint,
+                "difficulty": q.difficulty,
             })
         print(json.dumps({'version': Command.version, 'cpp_standard': settings.CPP_STD, 'questions': questions}))

--- a/quiz/management/commands/export_questions_to_repo.py
+++ b/quiz/management/commands/export_questions_to_repo.py
@@ -10,7 +10,6 @@ from quiz.management.commands import text_generator
 
 class Command(BaseCommand):
 
-
     def add_arguments(self, parser):
         parser.add_argument('repo_root', nargs=1)
 
@@ -47,10 +46,10 @@ def write_questions(repo_root, questions_root):
         print("Exporting question " + str(q.id))
         meta_data = {
             "id": q.id,
-            "result" : q.result,
-            "answer" : q.answer,
-            "state" : q.state,
-            "difficulty" : q.difficulty,
+            "result": q.result,
+            "answer": q.answer,
+            "state": q.state,
+            "difficulty": q.difficulty,
         }
         question_root = os.path.join(questions_root, str(q.id))
         os.mkdir(question_root)

--- a/quiz/management/commands/remove_section_numbers.py
+++ b/quiz/management/commands/remove_section_numbers.py
@@ -41,4 +41,3 @@ class Command(BaseCommand):
                     return
                 else:
                     print("**** Not committing diff!")
-

--- a/quiz/management/commands/update_questions_from_repo.py
+++ b/quiz/management/commands/update_questions_from_repo.py
@@ -9,12 +9,11 @@ from django.db.models import Q
 
 class Command(BaseCommand):
 
-
     def add_arguments(self, parser):
         parser.add_argument('repo_root', nargs=1)
 
     def get_question_ids(self, questions_root):
-        return [d for d in os.listdir(questions_root) if os.path.isdir(os.path.join(questions_root,d))]
+        return [d for d in os.listdir(questions_root) if os.path.isdir(os.path.join(questions_root, d))]
 
     def handle(self, *args, **options):
         questions_root = os.path.join(options['repo_root'][0], 'questions')
@@ -39,7 +38,7 @@ class Command(BaseCommand):
 
     def update_question(self, questions_root, question_id):
         question_root = os.path.join(questions_root, question_id)
-        print("Updating question '" + question_id + "' from '" + question_root + "'" )
+        print("Updating question '" + question_id + "' from '" + question_root + "'")
         question = Question.objects.get(pk=question_id)
         self.set_meta_data(question, os.path.join(question_root, 'meta_data.json'))
         self.set_question(question, os.path.join(question_root, 'question.cpp'))

--- a/quiz/models.py
+++ b/quiz/models.py
@@ -1,4 +1,4 @@
- # -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 import datetime
 import random
 import re
@@ -55,14 +55,14 @@ class Question(models.Model):
         return str(self.pk)
 
     def clean(self):
-        verbs = {'SCH':'schedule', 'PUB':'publish', 'ACC':'accept'}
+        verbs = {'SCH': 'schedule', 'PUB': 'publish', 'ACC': 'accept'}
         if self.state in ('PUB', 'SCH', 'ACC') and self.hint == '':
             raise ValidationError(f'Cannot {verbs[self.state]} a question without a hint')
         if self.state in ('PUB', 'SCH', 'ACC') and self.difficulty == 0:
             raise ValidationError(f'Cannot {verbs[self.state]} a question without a difficulty setting')
         if self.state in ('PUB', 'SCH') and self.reserved:
             raise ValidationError(f'Cannot {verbs[self.state]} a reserved question')
-        if self.tweet_text and not re.search("https?://",self.tweet_text):
+        if self.tweet_text and not re.search("https?://", self.tweet_text):
             raise ValidationError('Tweets must contain a url!')
 
     def save(self, *args, **kwargs):
@@ -87,7 +87,7 @@ class Quiz(models.Model):
     date_time = models.DateTimeField(auto_now_add=True)
 
     def get_ordered_questions(self):
-        #Order pseudo-randomly but not in order of primary key
+        # Order pseudo-randomly but not in order of primary key
         return self.questions.all().order_by('hint', 'id')
 
     def question_ids(self):

--- a/quiz/quiz_in_progress.py
+++ b/quiz/quiz_in_progress.py
@@ -14,7 +14,7 @@ class QuestionStats:
         score = self.skipped == False
         if self.used_hint:
             score -= .5
-        score *=  pow(.5, self.attempts)
+        score *= pow(.5, self.attempts)
         return score
 
 class QuizInProgress:
@@ -90,7 +90,7 @@ class QuizInProgress:
     def save(self):
         self.session.modified = True
         self.session['quiz_in_progress'] = self
-        self.session.set_expiry(60*60*24*365*10) #TODO akn DRY
+        self.session.set_expiry(60 * 60 * 24 * 365 * 10)  # TODO akn DRY
 
     def _reset_question_state(self):
         self.previous_explanation = None

--- a/quiz/templatetags/quiz_extras.py
+++ b/quiz/templatetags/quiz_extras.py
@@ -28,10 +28,10 @@ def standard_ref(text):
 
 def custom_linebreaks(text):
     return (text
-        .replace("\n", "<br />")
-        .replace("</p><br />", "</p>")
-        .replace("<br /><p>", "<p>")
-        .replace("</pre><br />", "</pre>"))
+            .replace("\n", "<br />")
+            .replace("</p><br />", "</p>")
+            .replace("<br /><p>", "<p>")
+            .replace("</pre><br />", "</pre>"))
 
 @register.filter(needs_autoescape=True)
 def to_html(text, autoescape=None):
@@ -42,8 +42,8 @@ def to_html(text, autoescape=None):
 
 @register.filter()
 def cpp_insights_link(question):
-    std = settings.CPP_STD.replace("C++","cpp")
-    return('https://cppinsights.io/lnk?code=%s&insightsOptions=%s&rev=1.0' %(base64.b64encode(question.question.encode()).decode('utf-8'), std))
+    std = settings.CPP_STD.replace("C++", "cpp")
+    return ('https://cppinsights.io/lnk?code=%s&insightsOptions=%s&rev=1.0' % (base64.b64encode(question.question.encode()).decode('utf-8'), std))
 
 @register.filter()
 def compiler_explorer_link(question):

--- a/quiz/test_active_quiz.py
+++ b/quiz/test_active_quiz.py
@@ -8,6 +8,6 @@ from quiz.test_helpers import *
 class ActiveQuizTest(TestCase):
     def test_shows_total_number_of_questions(self):
         create_questions(10)
-        quiz = Quiz.objects.get(key=create_quiz(10)) #TODO maybe that method should return object instead of key
+        quiz = Quiz.objects.get(key=create_quiz(10))  # TODO maybe that method should return object instead of key
         active = ActiveQuiz(quiz)
         self.assertEqual(10, active.total_questions())

--- a/quiz/test_fixed_quiz.py
+++ b/quiz/test_fixed_quiz.py
@@ -16,7 +16,7 @@ class get_unique_quiz_key_Test(TestCase):
         number_of_possible_keys = len(string.ascii_uppercase + string.digits)
         keys = []
         for i in range(1, number_of_possible_keys):
-            key  = fixed_quiz.get_unique_quiz_key(1)
+            key = fixed_quiz.get_unique_quiz_key(1)
             Quiz.objects.create(key=key)
             self.assertNotIn(key, keys)
             keys.append(key)
@@ -64,5 +64,5 @@ class create_quiz_Test(TestCase):
             fixed_quiz.create_quiz(1)
 
     def assertLooksKindOfRandom(self, question_ids):
-        #Only works if there are more questions in the db than we are asked to use in the quiz
+        # Only works if there are more questions in the db than we are asked to use in the quiz
         self.assertNotEqual(list(range(1, len(question_ids) + 1)), question_ids)

--- a/quiz/test_models.py
+++ b/quiz/test_models.py
@@ -6,33 +6,33 @@ from quiz.models import Question
 
 class QuestionTest(TestCase):
     @parameterized.expand([
-        ('PUB','publish'),
-        ('SCH','schedule'),
-        ('ACC','accept'),
+        ('PUB', 'publish'),
+        ('SCH', 'schedule'),
+        ('ACC', 'accept'),
     ])
     def test_limits_state_of_questions_without_difficulty_setting(self, state, verb):
-        q = Question(state=state, hint = 'hint', difficulty=0)
+        q = Question(state=state, hint='hint', difficulty=0)
         with self.assertRaises(ValidationError) as cm:
             q.save()
         self.assertIn(f'Cannot {verb} a question without a difficulty setting', str(cm.exception))
 
     @parameterized.expand([
-        ('PUB','publish'),
-        ('SCH','schedule'),
-        ('ACC','accept'),
+        ('PUB', 'publish'),
+        ('SCH', 'schedule'),
+        ('ACC', 'accept'),
     ])
     def test_limits_state_of_questions_without_hint(self, state, verb):
-        q = Question(state=state, hint = '', difficulty=1)
+        q = Question(state=state, hint='', difficulty=1)
         with self.assertRaises(ValidationError) as cm:
             q.save()
         self.assertIn(f'Cannot {verb} a question without a hint', str(cm.exception))
 
     @parameterized.expand([
-        ('PUB','publish'),
-        ('SCH','schedule'),
+        ('PUB', 'publish'),
+        ('SCH', 'schedule'),
     ])
     def test_limits_state_of_reserved_questions(self, state, verb):
-        q = Question(state=state, hint = 'hint', difficulty=1, reserved=True)
+        q = Question(state=state, hint='hint', difficulty=1, reserved=True)
         with self.assertRaises(ValidationError) as cm:
             q.save()
         self.assertIn(f'Cannot {verb} a reserved question', str(cm.exception))
@@ -49,9 +49,9 @@ class QuestionTest(TestCase):
         self.assertNotEqual(q.preview_key, q2.preview_key)
 
     def test_requires_url_in_tweet_text(self):
-        q = Question(state="SCH", hint = 'hint', tweet_text="hi", difficulty=1)
+        q = Question(state="SCH", hint='hint', tweet_text="hi", difficulty=1)
         with self.assertRaises(ValidationError) as cm:
             q.save()
         self.assertIn('Tweets must contain a url!', str(cm.exception))
-        Question(state="SCH", hint = 'hint', tweet_text="See http://example.com", difficulty=1).save()
-        Question(state="SCH", hint = 'hint', tweet_text="See https://example.com", difficulty=1).save()
+        Question(state="SCH", hint='hint', tweet_text="See http://example.com", difficulty=1).save()
+        Question(state="SCH", hint='hint', tweet_text="See https://example.com", difficulty=1).save()

--- a/quiz/test_quiz_in_progress.py
+++ b/quiz/test_quiz_in_progress.py
@@ -91,10 +91,10 @@ class QuizInProgressTest(TestCase):
 
     def test_when_three_attempts_are_made__score_is_divided_by_eight(self):
         self.set_up()
-        for i in range(0,3):
+        for i in range(0, 3):
             self.answer_current_question_incorrectly()
         self.answer_current_question_correctly()
-        self.assertEqual(1.0/8, self.in_progress.score())
+        self.assertEqual(1.0 / 8, self.in_progress.score())
 
     def test_when_hint_is_used__score_is_reduced_by_half_a_point(self):
         self.set_up()
@@ -119,7 +119,7 @@ class QuizInProgressTest(TestCase):
 
     def test_when_we_somehow_get_index_error__get_current_question_provides_good_info(self):
         self.set_up(2)
-        for i in range(0,2):
+        for i in range(0, 2):
             self.answer_current_question_correctly()
         try:
             self.in_progress.get_current_question()
@@ -129,10 +129,10 @@ class QuizInProgressTest(TestCase):
 
     def answer_current_question_correctly(self):
         question = self.in_progress.get_current_question()
-        request = RequestFactory().get('', data={'result' : question.result, 'answer' : question.answer})
+        request = RequestFactory().get('', data={'result': question.result, 'answer': question.answer})
         self.in_progress.answer(request)
 
     def answer_current_question_incorrectly(self):
         question = self.in_progress.get_current_question()
-        request = RequestFactory().post('', data={'result' : question.result, 'answer' : 'WRONG ANSWER'})
+        request = RequestFactory().post('', data={'result': question.result, 'answer': 'WRONG ANSWER'})
         self.in_progress.answer(request)

--- a/quiz/test_session.py
+++ b/quiz/test_session.py
@@ -21,7 +21,7 @@ class UserDataTest(unittest.TestCase):
     def test_given_existing_session__correct_answers_are_still_there(self):
         old_data = UserData({})
         old_data.register_correct_answer(16)
-        session = {'user_data' : old_data}
+        session = {'user_data': old_data}
         new_data = UserData(session)
         self.assertSetEqual({16}, new_data.get_correctly_answered_questions())
 
@@ -31,23 +31,23 @@ class UserDataTest(unittest.TestCase):
         s.clear_correct_answers()
         self.assertSetEqual(set(), s.get_correctly_answered_questions())
 
-        
 
 class save_user_dataTest(unittest.TestCase):
-    
-        def test_sets_modified(self):
-            session = mock.MagicMock()
-            save_user_data(None, session)
-            self.assertTrue(session.modified)
-    
-        def test_sets_user_data(self):
-            session = mock.MagicMock()
-            user_data = UserData({})
-            user_data.register_correct_answer(53)
-            save_user_data(user_data, session)
-            session.__setitem__.assert_called_once_with('user_data', user_data)
 
-        def test_sets_expiry(self):
-            session = mock.MagicMock()
-            save_user_data(None, session)
-            session.set_expiry.assert_called_once_with(315360000)
+    def test_sets_modified(self):
+        session = mock.MagicMock()
+        save_user_data(None, session)
+        self.assertTrue(session.modified)
+
+    def test_sets_user_data(self):
+
+        session = mock.MagicMock()
+        user_data = UserData({})
+        user_data.register_correct_answer(53)
+        save_user_data(user_data, session)
+        session.__setitem__.assert_called_once_with('user_data', user_data)
+
+    def test_sets_expiry(self):
+        session = mock.MagicMock()
+        save_user_data(None, session)
+        session.set_expiry.assert_called_once_with(315360000)

--- a/quiz/urls.py
+++ b/quiz/urls.py
@@ -3,18 +3,18 @@ from django.views.generic.base import TemplateView
 
 from quiz import views
 
-app_name='quiz'
+app_name = 'quiz'
 urlpatterns = [
     url(r'^quiz/question/(?P<question_id>\d+)', views.question, name='question'),
     url(r'^quiz/giveup/(?P<question_id>\d+)', views.giveup, name='giveup'),
     url(r'^quiz/clear', views.clear, name='clear'),
     url(r'^quiz/random', views.random_question, name='random'),
-    url(r'^quiz/created', TemplateView.as_view(template_name = 'quiz/created.html')),
-    url(r'^quiz/no_questions', TemplateView.as_view(template_name = 'quiz/no_questions.html')),
+    url(r'^quiz/created', TemplateView.as_view(template_name='quiz/created.html')),
+    url(r'^quiz/no_questions', TemplateView.as_view(template_name='quiz/no_questions.html')),
     url(r'^quiz/create', views.create, name='create'),
     url(r'^quiz/categorize', views.categorize, name='categorize'),
-    url(r'^quiz/about', TemplateView.as_view(template_name = 'quiz/help.html')),
-    url(r'^quiz/help', TemplateView.as_view(template_name = 'quiz/help.html')),
+    url(r'^quiz/about', TemplateView.as_view(template_name='quiz/help.html')),
+    url(r'^quiz/help', TemplateView.as_view(template_name='quiz/help.html')),
     url(r'^quiz/start', views.start, name='start'),
     url(r'^quiz/dismiss_training_msg', views.dismiss_training_msg, name='dismiss_training_msg'),
     url(r'^q/(?P<quiz_key>\w+)', views.quiz, name='quiz'),

--- a/quiz/util.py
+++ b/quiz/util.py
@@ -1,4 +1,4 @@
-#http://stackoverflow.com/a/4581997
+# http://stackoverflow.com/a/4581997
 def get_client_ip(request):
     x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
     if x_forwarded_for:

--- a/quiz/views.py
+++ b/quiz/views.py
@@ -52,12 +52,12 @@ def categorize(request):
     else:
         changed = int(request.GET.get('changed', 0))
         questions = Question.objects.filter(state='PUB').order_by('difficulty')\
-                    .annotate(num_answers=Count('usersanswer'))
+            .annotate(num_answers=Count('usersanswer'))
         for q in questions:
             num_correct = len(UsersAnswer.objects.filter(question=q, correct=True))
             q.percentage_correct = num_correct * 100.0 / q.num_answers if q.num_answers > 0 else 0
-        return render(request, 'quiz/categorize.html' ,
-            {'questions': questions, 'changed':changed})
+        return render(request, 'quiz/categorize.html',
+                      {'questions': questions, 'changed': changed})
 
 def create(request):
     if request.method == 'POST':
@@ -69,7 +69,7 @@ def create(request):
     else:
         form = QuestionForm()
     return render(request, 'quiz/create.html',
-        {'form':form, 'title':'Create question'})
+                  {'form': form, 'title': 'Create question'})
 
 def preview_with_key(request, question_id):
     key = request.GET.get('preview_key')
@@ -148,9 +148,9 @@ def quiz(request, quiz_key):
 
 def suggest_quiz_similar_to(key, request):
     suggestions = reversed(sorted(
-            [(difflib.SequenceMatcher(None, q.key, key).ratio(), q.key)
-                for q in Quiz.objects.all()]
-                    )[-5:])
+        [(difflib.SequenceMatcher(None, q.key, key).ratio(), q.key)
+         for q in Quiz.objects.all()]
+    )[-5:])
     d = {
         'key': key,
         'suggestions': suggestions,
@@ -163,7 +163,7 @@ def dismiss_training_msg(request):
     save_user_data(user_data, request.session)
     return HttpResponse('')
 
-#TODO what if there are no questions
+# TODO what if there are no questions
 def get_unanswered_question(user_data):
     available_questions = [q.id for q in Question.objects.filter(state='PUB')]
     if len(available_questions) == 0:


### PR DESCRIPTION
Automatically reformat using the following command: 

```shell
autopep8 --ignore=E302,E401,E402,E501 --in-place --recursive "quiz/" "cppquiz/"
```

And then manually exclude the code that is commented out, since `autopep8` doesn't support the `pycodestyle`'s error E114.