### PR TITLE
Deduplicate common snippets

### DIFF
--- a/quiz/fixed_quiz.py
+++ b/quiz/fixed_quiz.py
@@ -2,6 +2,7 @@ import random
 import string
 
 from quiz.models import Question, Quiz, QuestionInQuiz
+from quiz.util import get_published_questions
 
 nof_questions_in_quiz = 10
 
@@ -19,7 +20,7 @@ def make_quiz_key(length):
 
 def create_quiz(nof_questions=nof_questions_in_quiz):
     quiz = Quiz.objects.create()
-    question_ids = [q.pk for q in Question.objects.filter(state='PUB')]
+    question_ids = [q.pk for q in get_published_questions()]
     used_questions = random.sample(question_ids, nof_questions)
     for pk in used_questions:
         qinq = QuestionInQuiz(question=Question.objects.get(pk=pk), quiz=quiz)

--- a/quiz/integration_tests/test_training.py
+++ b/quiz/integration_tests/test_training.py
@@ -9,51 +9,51 @@ from quiz.test_helpers import create_questions
 
 class TrainingIntegrationTest(TestCase):
     def test_when_viewing_an_unpublished_question__gets_404(self):
-        question = self.create_question(False)
+        [question] = create_questions(1, state='NEW')
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}))
         self.assertEqual(404, response.status_code)
 
     def test_when_viewing_a_published_question__gets_it(self):
-        question = self.create_question(True)
+        [question] = create_questions(1, state='PUB', question='fluppa')
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}))
         self.assertContains(response, 'fluppa')
 
     def test_when_viewing_an_unpublished_question_with_a_preview_key__gets_it(self):
-        question = self.create_question(False, 'abc123')
+        [question] = create_questions(1, state='NEW', question='fluppa', preview_key='abc123')
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}),
                                    {'preview_key': 'abc123'})
         self.assertContains(response, 'fluppa')
 
     def test_when_viewing_a_published_question_with_a_preview_key__gets_it(self):
-        question = self.create_question(True, 'abc123')
+        [question] = create_questions(1, state='PUB', question='fluppa', preview_key='abc123')
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}),
                                    {'preview_key': 'abc123'})
         self.assertContains(response, 'fluppa')
 
     def test_when_viewing_an_unpublished_question_with_a_wrong_preview_key__gets_404(self):
-        question = self.create_question(False, 'abc123')
+        [question] = create_questions(1, state='NEW', preview_key='abc123')
         response = self.client.get("/quiz/question/%d?preview_key=%s" % (question.pk, 'wrong'))
         self.assertEqual(404, response.status_code)
 
     def test_when_viewing_an_unpublished_question_with_an_empty_preview_key__gets_404(self):
-        question = self.create_question(False, '')
+        [question] = create_questions(1, state='NEW', preview_key='')
         response = self.client.get("/quiz/question/%d?preview_key=%s" % (question.pk, ''))
         self.assertEqual(404, response.status_code)
 
     def test_when_viewing_an_unanswered_question__is_told_that_attempts_are_needed_before_giving_up_is_allowed(self):
-        question = self.create_question(True)
+        [question] = create_questions(1)
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}))
         self.assertContains(response, 'make 3 more attempts first')
 
     def test_when_viewing_a_correctly_answered_question__is_not_told_about_giving_up(self):
-        question = self.create_question(True)
+        [question] = create_questions(1)
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}),
                                    {'did_answer': 'answer', 'result': question.result, 'answer': question.answer})
         self.assertContains(response, 'Correct')
         self.assertNotContains(response, 'more attempts first')
 
     def test_when_viewing_an_incorrectly_answered_question__is_told_that_more_attempts_are_needed_before_giving_up_is_allowed(self):
-        question = self.create_question(True)
+        [question] = create_questions(1)
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}))
         self.assertContains(response, 'make 3 more attempts first')
         response = self.answer_question_incorrectly(question)
@@ -64,29 +64,22 @@ class TrainingIntegrationTest(TestCase):
         self.assertNotContains(response, 'more attempts first')
 
     def test_when_less_than_three_attempts_were_made__going_directly_to_the_giveup_page_is_not_allowed(self):
-        question = self.create_question(True)
+        [question] = create_questions(1)
         response = self.client.get(reverse('quiz:giveup', kwargs={'question_id': question.pk}))
         self.assertEqual(404, response.status_code)
 
     def test_when_viewing_a_retracted_question__is_warned(self):
-        question = self.create_question(True)
-        question.state = 'RET'
-        question.retraction_message = 'A very good reason'
-        question.save()
+        [question] = create_questions(1, state='RET', retraction_message='A very good reason')
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}))
         self.assertContains(response, 'This question has been retracted')
         self.assertContains(response, 'A very good reason')
 
     def test_when_viewing_a_question__it_gets_timestamped(self):
-        question = self.create_question(True)
+        [question] = create_questions(1)
         self.assertIsNone(question.last_viewed)
         response = self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}))
         self.assertEqual(200, response.status_code)
         self.assertLess((timezone.now() - Question.objects.get(pk=question.pk).last_viewed).total_seconds(), 10)
-
-    def create_question(self, published, preview_key=''):
-        return Question.objects.create(state='PUB' if published else 'NEW', question='fluppa', answer='buppa',
-                                       result='OK', hint='jotta', difficulty=1, preview_key=preview_key)
 
     def answer_question_incorrectly(self, question):
         return self.client.get(reverse('quiz:question', kwargs={'question_id': question.pk}),

--- a/quiz/management/commands/dump_published_questions.py
+++ b/quiz/management/commands/dump_published_questions.py
@@ -2,6 +2,7 @@ import json
 
 from django.core.management.base import BaseCommand, CommandError
 from quiz.models import *
+from quiz.util import get_published_questions
 from cppquiz import settings
 
 
@@ -10,7 +11,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         questions = []
-        for q in Question.objects.filter(state='PUB'):
+        for q in get_published_questions():
             questions.append({
                 "id": q.id,
                 "question": q.question,

--- a/quiz/test_auto_publish.py
+++ b/quiz/test_auto_publish.py
@@ -5,27 +5,25 @@ from django.test import TestCase
 from django.utils import timezone
 
 from quiz.models import Question
+from quiz.test_helpers import create_questions
 
 
 class AutoPublishTest(TestCase):
 
     def test_publishes_scheduled_question_from_the_past(self):
         past = timezone.now() - timedelta(hours=1)
-        q = Question(state="SCH", hint="hint", difficulty=1, publish_time=past)
-        q.save()
+        [q] = create_questions(1, state="SCH", publish_time=past)
         call_command("auto_publish", "--skip-tweet")
         self.assertEqual("PUB", Question.objects.get(pk=q.pk).state)
 
     def test_does_not_publish_unscheduled_question_from_the_past(self):
         past = timezone.now() - timedelta(hours=1)
-        q = Question(state="ACC", hint="hint", difficulty=1, publish_time=past)
-        q.save()
+        [q] = create_questions(1, state="ACC", publish_time=past)
         call_command("auto_publish", "--skip-tweet")
         self.assertEqual("ACC", Question.objects.get(pk=q.pk).state)
 
     def test_does_not_publish_scheduled_question_from_the_future(self):
         future = timezone.now() + timedelta(hours=1)
-        q = Question(state="SCH", hint="hint", difficulty=1, publish_time=future)
-        q.save()
+        [q] = create_questions(1, state="SCH", publish_time=future)
         call_command("auto_publish", "--skip-tweet")
         self.assertEqual("SCH", Question.objects.get(pk=q.pk).state)

--- a/quiz/test_fixed_quiz.py
+++ b/quiz/test_fixed_quiz.py
@@ -48,11 +48,7 @@ class create_quiz_Test(TestCase):
         self.assertNotEqual(sorted(pks), pks)
 
     def test_creating_a_quiz__only_uses_published_questions(self):
-        create_questions(4)
-        q0 = Question.objects.all()[0]
-        q1 = Question.objects.all()[1]
-        q2 = Question.objects.all()[2]
-        q3 = Question.objects.all()[3]
+        [q0, q1, q2, q3] = create_questions(4)
         q0.state = 'NEW'
         q1.state = 'RET'
         q2.state = 'REF'

--- a/quiz/test_helpers.py
+++ b/quiz/test_helpers.py
@@ -5,10 +5,22 @@ import random
 from quiz.models import Question
 
 
-def create_questions(nof_questions):
-    for i in range(0, nof_questions):
-        Question.objects.create(question=str(i), answer=str(i), result='OK', state='PUB',
-                                hint=random_hint(), difficulty=1, explanation='because ' + str(i))
+def create_questions(nof_questions, **kwargs):
+    question_kwargs = kwargs.copy()
+    question_kwargs.setdefault('state', 'PUB')
+    question_kwargs.setdefault('difficulty', 1)
+
+    questions = []
+
+    for i in range(nof_questions):
+        question_kwargs['question'] = kwargs.get('question', str(i))
+        question_kwargs['answer'] = kwargs.get('answer', str(i))
+        question_kwargs['hint'] = kwargs.get('hint', random_hint())
+        question_kwargs['explanation'] = kwargs.get('explanation', f'because {i}')
+
+        questions.append(Question.objects.create(**question_kwargs))
+
+    return questions
 
 
 def get_question_pk(html):

--- a/quiz/test_session.py
+++ b/quiz/test_session.py
@@ -5,54 +5,55 @@ from quiz.game_data import *
 from quiz.models import *
 
 
+def create_session_with_answers_to(questions):
+    session = {}
+    user_data = UserData(session)
+
+    for question in questions:
+        user_data.register_correct_answer(question.pk)
+
+    return user_data
+
+
 class UserDataTest(unittest.TestCase):
 
     def test_given_new_session__has_no_correct_answers(self):
-        session = {}
-        s = UserData(session)
-        self.assertSetEqual(set(), s.get_correctly_answered_questions())
+        user_data = create_session_with_answers_to(tuple())
+        self.assertSetEqual(set(), user_data.get_correctly_answered_questions())
 
     def test_given_new_session__after_a_correct_answer_to_a_published_question_is_registered__it_is_listed_as_answered(self):
         q1 = Question.objects.create(state='PUB', difficulty=1)
         q2 = Question.objects.create(state='PUB', difficulty=1)
-        session = {}
-        s = UserData(session)
-        s.register_correct_answer(q1.pk)
-        self.assertSetEqual({q1.pk}, s.get_correctly_answered_questions())
-        s.register_correct_answer(q2.pk)
-        self.assertSetEqual({q1.pk, q2.pk}, s.get_correctly_answered_questions())
+        user_data = create_session_with_answers_to((q1,))
+        self.assertSetEqual({q1.pk}, user_data.get_correctly_answered_questions())
+        user_data.register_correct_answer(q2.pk)
+        self.assertSetEqual({q1.pk, q2.pk}, user_data.get_correctly_answered_questions())
 
     def test_given_new_session__after_a_correct_answer_to_a_retracted_question_is_registered__it_is_not_listed_as_answered(self):
         q = Question.objects.create(state='RET', difficulty=1)
-        session = {}
-        s = UserData(session)
-        s.register_correct_answer(q.pk)
-        self.assertSetEqual(set(), s.get_correctly_answered_questions())
+        user_data = create_session_with_answers_to((q,))
+        self.assertSetEqual(set(), user_data.get_correctly_answered_questions())
 
     def test_given_new_session__after_a_published_question_becomes_retracted__its_answer_is_not_listed_as_answered(self):
         q = Question.objects.create(state='PUB', difficulty=1)
-        session = {}
-        s = UserData(session)
-        s.register_correct_answer(q.pk)
-        self.assertSetEqual({q.pk}, s.get_correctly_answered_questions())
+        user_data = create_session_with_answers_to((q,))
+        self.assertSetEqual({q.pk}, user_data.get_correctly_answered_questions())
         q.state = 'RET'
         q.save()
-        self.assertSetEqual(set(), s.get_correctly_answered_questions())
+        self.assertSetEqual(set(), user_data.get_correctly_answered_questions())
 
     def test_given_existing_session__correct_answers_are_still_there(self):
         q = Question.objects.create(state='PUB', difficulty=1)
-        old_data = UserData({})
-        old_data.register_correct_answer(q.pk)
+        old_data = create_session_with_answers_to((q,))
         session = {'user_data': old_data}
         new_data = UserData(session)
         self.assertSetEqual({q.pk}, new_data.get_correctly_answered_questions())
 
     def test_clear_correct_answers(self):
         q = Question.objects.create(state='PUB', difficulty=1)
-        s = UserData({})
-        s.register_correct_answer(q.pk)
-        s.clear_correct_answers()
-        self.assertSetEqual(set(), s.get_correctly_answered_questions())
+        user_data = create_session_with_answers_to((q,))
+        user_data.clear_correct_answers()
+        self.assertSetEqual(set(), user_data.get_correctly_answered_questions())
 
 
 class save_user_dataTest(unittest.TestCase):
@@ -65,8 +66,7 @@ class save_user_dataTest(unittest.TestCase):
     def test_sets_user_data(self):
         q = Question.objects.create(state='PUB', difficulty=1)
         session = mock.MagicMock()
-        user_data = UserData({})
-        user_data.register_correct_answer(q.pk)
+        user_data = create_session_with_answers_to((q,))
         save_user_data(user_data, session)
         session.__setitem__.assert_called_once_with('user_data', user_data)
 

--- a/quiz/test_session.py
+++ b/quiz/test_session.py
@@ -2,7 +2,7 @@ import mock
 import unittest
 
 from quiz.game_data import *
-from quiz.models import *
+from quiz.test_helpers import *
 
 
 def create_session_with_answers_to(questions):
@@ -22,20 +22,19 @@ class UserDataTest(unittest.TestCase):
         self.assertSetEqual(set(), user_data.get_correctly_answered_questions())
 
     def test_given_new_session__after_a_correct_answer_to_a_published_question_is_registered__it_is_listed_as_answered(self):
-        q1 = Question.objects.create(state='PUB', difficulty=1)
-        q2 = Question.objects.create(state='PUB', difficulty=1)
+        [q1, q2] = create_questions(2, state='PUB')
         user_data = create_session_with_answers_to((q1,))
         self.assertSetEqual({q1.pk}, user_data.get_correctly_answered_questions())
         user_data.register_correct_answer(q2.pk)
         self.assertSetEqual({q1.pk, q2.pk}, user_data.get_correctly_answered_questions())
 
     def test_given_new_session__after_a_correct_answer_to_a_retracted_question_is_registered__it_is_not_listed_as_answered(self):
-        q = Question.objects.create(state='RET', difficulty=1)
+        [q] = create_questions(1, state='RET')
         user_data = create_session_with_answers_to((q,))
         self.assertSetEqual(set(), user_data.get_correctly_answered_questions())
 
     def test_given_new_session__after_a_published_question_becomes_retracted__its_answer_is_not_listed_as_answered(self):
-        q = Question.objects.create(state='PUB', difficulty=1)
+        [q] = create_questions(1, state='PUB')
         user_data = create_session_with_answers_to((q,))
         self.assertSetEqual({q.pk}, user_data.get_correctly_answered_questions())
         q.state = 'RET'
@@ -43,14 +42,14 @@ class UserDataTest(unittest.TestCase):
         self.assertSetEqual(set(), user_data.get_correctly_answered_questions())
 
     def test_given_existing_session__correct_answers_are_still_there(self):
-        q = Question.objects.create(state='PUB', difficulty=1)
+        [q] = create_questions(1)
         old_data = create_session_with_answers_to((q,))
         session = {'user_data': old_data}
         new_data = UserData(session)
         self.assertSetEqual({q.pk}, new_data.get_correctly_answered_questions())
 
     def test_clear_correct_answers(self):
-        q = Question.objects.create(state='PUB', difficulty=1)
+        [q] = create_questions(1)
         user_data = create_session_with_answers_to((q,))
         self.assertSetEqual({q.pk}, user_data.get_correctly_answered_questions())
         user_data.clear_correct_answers()
@@ -65,7 +64,7 @@ class save_user_dataTest(unittest.TestCase):
         self.assertTrue(session.modified)
 
     def test_sets_user_data(self):
-        q = Question.objects.create(state='PUB', difficulty=1)
+        [q] = create_questions(1)
         session = mock.MagicMock()
         user_data = create_session_with_answers_to((q,))
         save_user_data(user_data, session)

--- a/quiz/test_session.py
+++ b/quiz/test_session.py
@@ -52,6 +52,7 @@ class UserDataTest(unittest.TestCase):
     def test_clear_correct_answers(self):
         q = Question.objects.create(state='PUB', difficulty=1)
         user_data = create_session_with_answers_to((q,))
+        self.assertSetEqual({q.pk}, user_data.get_correctly_answered_questions())
         user_data.clear_correct_answers()
         self.assertSetEqual(set(), user_data.get_correctly_answered_questions())
 

--- a/quiz/util.py
+++ b/quiz/util.py
@@ -1,3 +1,6 @@
+from quiz.models import Question
+
+
 # http://stackoverflow.com/a/4581997
 def get_client_ip(request):
     x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
@@ -6,3 +9,7 @@ def get_client_ip(request):
     else:
         ip = request.META.get('REMOTE_ADDR')
     return ip
+
+
+def get_published_questions():
+    return Question.objects.filter(state='PUB')


### PR DESCRIPTION
Extracts:

- `Question.objects.filter(state='PUB')`
- `session`, `UserData` and `register_correct_answer()`

Makes the `create_questions()` helper more flexible to use it in more contexts.

And makes an additional assertion in `test_clear_correct_answers` as requested.
