### PR TITLE
Update Compiler Explorer links

### DIFF
--- a/quiz/templatetags/quiz_extras.py
+++ b/quiz/templatetags/quiz_extras.py
@@ -67,15 +67,16 @@ def compiler_explorer_link(question):
     compiler_details = {
         "gcc": {
             "compiler": "gsnapshot",
-            "options": f"-std={settings.CPP_STD.lower()}"
+            "options": f"-std={settings.CPP_STD.lower()} -Wall -Wextra -Wno-unused -Wunused-value"
         },
         "clang": {
             "compiler": "clang_trunk",
-            "options": f"-std={settings.CPP_STD.lower()} -stdlib=libc++"
+            "options": f"-std={settings.CPP_STD.lower()} -stdlib=libc++ -Wall -Wextra -Wno-unused"
+                       " -Wno-unused-parameter -Wunused-result -Wunused-value"
         },
         "msvc": {
             "compiler": "vcpp_v19_latest_x64",
-            "options": f"/std:{settings.CPP_STD.lower()}"
+            "options": f"/std:{settings.CPP_STD.lower()} /W4 /wd4100 /wd4101 /wd4189"
         },
     }
 

--- a/quiz/templatetags/quiz_extras.py
+++ b/quiz/templatetags/quiz_extras.py
@@ -70,7 +70,7 @@ def compiler_explorer_link(question):
         "componentState": {
             "id": 1,
             "source": 1,
-            "compiler": "g92",
+            "compiler": "gsnapshot",
             "filters": {"b": 1, "execute": 1, "intel": 1, "commentOnly": 1, "directives": 1},
             "options": f"-std={settings.CPP_STD.lower()}",
         },

--- a/quiz/templatetags/quiz_extras.py
+++ b/quiz/templatetags/quiz_extras.py
@@ -64,15 +64,29 @@ def compiler_explorer_link(question):
         },
     }
 
+    compiler_details = {
+        "gcc": {
+            "compiler": "gsnapshot",
+            "options": f"-std={settings.CPP_STD.lower()}"
+        },
+        "clang": {
+            "compiler": "clang_trunk",
+            "options": f"-std={settings.CPP_STD.lower()} -stdlib=libc++"
+        },
+        "msvc": {
+            "compiler": "vcpp_v19_latest_x64",
+            "options": f"/std:{settings.CPP_STD.lower()}"
+        },
+    }
+
     compiler = {
         "type": "component",
         "componentName": "compiler",
         "componentState": {
             "id": 1,
             "source": 1,
-            "compiler": "gsnapshot",
             "filters": {"b": 1, "execute": 1, "intel": 1, "commentOnly": 1, "directives": 1},
-            "options": f"-std={settings.CPP_STD.lower()}",
+            **compiler_details["gcc"],
         },
     }
 
@@ -82,12 +96,25 @@ def compiler_explorer_link(question):
         "componentState": {"compiler": 1, "source": 1},
     }
 
+    executors = [{
+        "type": "component",
+        "componentName": "executor",
+        "componentState": {
+            "id": compiler_id,
+            "source": 1,
+            "compilationPanelShown": 1,
+            **compiler_details[compiler_name],
+        },
+    } for compiler_id, compiler_name in enumerate(("clang", "msvc"), start=1)]
+
     obj = {
         "version": 4,
         "content": [
             {
                 "type": "row",
-                "content": [editor, {"type": "column", "content": [compiler, output]}],
+                "content": [editor,
+                            {"type": "column", "content": [compiler, output]},
+                            {"type": "column", "width": 25, "content": executors}],
             }
         ],
     }


### PR DESCRIPTION
- switch GCC 9.2 to trunk
- add execution results of the 3 main compilers
- add warnings

Closes https://github.com/knatten/cppquiz/issues/255.