### PR TITLE
Specify explicit editor lang for Compiler Explorer links

### DIFF
--- a/quiz/templatetags/quiz_extras.py
+++ b/quiz/templatetags/quiz_extras.py
@@ -58,6 +58,7 @@ def compiler_explorer_link(question):
         "componentName": "codeEditor",
         "componentState": {
             "id": 1,
+            "lang": "c++",
             "source": question.question,
             "options": {"compileOnChange": True, "colouriseAsm": True},
         },


### PR DESCRIPTION
Fixes https://github.com/compiler-explorer/compiler-explorer/issues/4817.