### PR TITLE
Add command to ensure all questions have preview key

### DIFF
--- a/quiz/management/commands/ensure_preview_key.py
+++ b/quiz/management/commands/ensure_preview_key.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+
+from quiz.models import Question, generate_preview_key
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        questions = Question.objects.filter(preview_key='')
+        print(f"Found {len(questions)} questions without a preview key, assigning them one")
+        for question in Question.objects.filter(preview_key=''):
+            question.preview_key = generate_preview_key()
+            question.save()
+            print(".", end="")
+        print("\nDone")


### PR DESCRIPTION
Some of the older questions were created before we started having preview keys. This command assigns a preview key to these questions.