### PR TITLE
Stop spamming about invalid http hosts

### DIFF
--- a/cppquiz/settings.py
+++ b/cppquiz/settings.py
@@ -158,8 +158,15 @@ LOGGING = {
             'filename': here('quiz.log'),
             'formatter': 'simple_stamped',
         },
+        'null': {
+            'class': 'logging.NullHandler',
+        },
     },
     'loggers': {
+        'django.security.DisallowedHost': {
+            'handlers': ['null'],
+            'propagate': False,
+        },
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',


### PR DESCRIPTION
After moving to the new server where everyone can reach the IP/port that Django itself is running on, we get a bunch of errors like these whenever someone tries to use an invalid host:

> [Django] ERROR (EXTERNAL IP): Invalid HTTP_HOST header: '(...)'. You
> may need to add '(...)' to ALLOWED_HOSTS.

There's no point in looking at these, the only allowed host we care about is already configured. And since we don't control the http server, we can't block these requests before they hit Django.