### PR TITLE
Avoid custom code for linebreaks

### DIFF
--- a/quiz/templatetags/quiz_extras.py
+++ b/quiz/templatetags/quiz_extras.py
@@ -28,20 +28,11 @@ def standard_ref(text):
     return re.sub(regex, format_reference, text)
 
 
-def custom_linebreaks(text):
-    return (text
-            .replace("\n", "<br />")
-            .replace("</p><br />", "</p>")
-            .replace("<br /><p>", "<p>")
-            .replace("</pre><br />", "</pre>"))
-
-
 @register.filter(needs_autoescape=True)
 def to_html(text, autoescape=None):
     return mark_safe(
         standard_ref(
-            custom_linebreaks(
-                markdown.markdown(text))))
+            markdown.markdown(text, extensions=['nl2br'])))
 
 
 @register.filter()


### PR DESCRIPTION
Avoid custom code for linebreaks

We want newlines to be treated as hard breaks; like StackOverflow and
GitHub flavored Markdown do. Previously this was done with a custom
hack, let's use an officially supported extension to our markdown
renderer instead.

Fixes https://github.com/knatten/cppquiz23/issues/257
Fixes #343
Helps with #345
