### PR TITLE
Support more chars in refs

### DIFF
--- a/quiz/tests/unit/test_quiz_extras.py
+++ b/quiz/tests/unit/test_quiz_extras.py
@@ -9,23 +9,26 @@ class standard_ref_Test(unittest.TestCase):
 
     def test_given_just_section(self):
         self.assertEqual(
-            '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">§[foo]</a></em>',
+            '*[§[foo]](https://timsong-cpp.github.io/cppwp/n4659/foo)*',
             standard_ref('§[foo]'))
         self.assertEqual(
-            '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar">§[foo.bar]</a></em>',
+            '*[§[foo.bar]](https://timsong-cpp.github.io/cppwp/n4659/foo.bar)*',
             standard_ref('§[foo.bar]'))
         self.assertEqual(
-            '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo::bar">§[foo::bar]</a></em>',
+            '*[§[foo::bar]](https://timsong-cpp.github.io/cppwp/n4659/foo::bar)*',
             standard_ref('§[foo::bar]'))
 
     def test_given_section_and_paragraph(self):
         self.assertEqual(
-            '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar#1.2">§[foo.bar]¶1.2</a></em>',
+            '*[§[foo.bar]¶1.2](https://timsong-cpp.github.io/cppwp/n4659/foo.bar#1.2)*',
             standard_ref('§[foo.bar]¶1.2'))
+        self.assertEqual(
+            '*[§[foo]¶note-1](https://timsong-cpp.github.io/cppwp/n4659/foo#note-1)*',
+            standard_ref('§[foo]¶note-1'))
 
     def test_doesnt_include_too_much(self):
         self.assertEqual(
-            '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo.bar#1">§[foo.bar]¶1</a></em>.', standard_ref('§[foo.bar]¶1.'))
+            '*[§[foo.bar]¶1](https://timsong-cpp.github.io/cppwp/n4659/foo.bar#1)*.', standard_ref('§[foo.bar]¶1.'))
 
     def test_doesnt_try_to_format_numbered_references(self):
         self.assertEqual('§1.2.3', standard_ref('§1.2.3'))
@@ -33,6 +36,6 @@ class standard_ref_Test(unittest.TestCase):
 
     def test_given_multiple_paragraphs(self):
         self.assertEqual(
-            '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/foo">§[foo]</a></em>'
-            '<em><a href="https://timsong-cpp.github.io/cppwp/n4659/bar">§[bar]</a></em>',
+            '*[§[foo]](https://timsong-cpp.github.io/cppwp/n4659/foo)*'
+            '*[§[bar]](https://timsong-cpp.github.io/cppwp/n4659/bar)*',
             standard_ref('§[foo]§[bar]'))


### PR DESCRIPTION
All currently existing refs in cppquiz are supported, 297 out of 20945 in C++23 index are unsupported (160 containing an asterisk, 131 ending in a right parenthesis, 4 ending in a quotation mark, 2 ending in an exclamation mark).

Fixes https://github.com/knatten/cppquiz/issues/344.