### PR TITLE
Better error handling for posting to socials

### DIFF
--- a/quiz/management/commands/auto_publish.py
+++ b/quiz/management/commands/auto_publish.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import traceback
 import requests
 import datetime
 from pathlib import Path
@@ -19,18 +20,36 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         skip_socials = options["skip_socials"]
+        had_failure = False
 
         for q in Question.objects.filter(state='SCH', publish_time__lte=timezone.now()):
             print(f"Publishing question {q}")
             q.state = 'PUB'
             q.save()
-            if (q.socials_text):
+            if q.socials_text:
                 if skip_socials:
                     print("Skipping posting to social media!")
                 else:
-                    self.post_to_x()
-                    self.post_to_bluesky(q.socials_text)
-                    self.post_to_mastodon(q.socials_text)
+                    had_failure |= self.post_to_socials(q.socials_text)
+
+        if had_failure:
+            sys.exit(1)
+
+    def post_to_socials(self, content):
+        platforms = [
+            ("X", self.post_to_x),
+            ("Bluesky", lambda: self.post_to_bluesky(content)),
+            ("Mastodon", lambda: self.post_to_mastodon(content)),
+        ]
+        had_failure = False
+        for name, post in platforms:
+            try:
+                post()
+            except Exception:
+                had_failure = True
+                print(f"Failed to post question to {name}:", file=sys.stderr)
+                traceback.print_exc()
+        return had_failure
 
     def post_to_x(self):
         content = "We just published a new question! Follow us on Bluesky @cppquiz.bsky.social or Mastodon @cppquiz@mastodon.online for updates. For obvious reasons, no longer post to Elon Musk's X."


### PR DESCRIPTION
Previously, if there was a problem posting to one service, we'd throw and skip the others. Instead loop over all of them and print any errors, exiting non-zero if at least one failed.

In practice, this keeps the behavior that I as an admin get an email when there is a problem.